### PR TITLE
Ignore "Returns" statements in class-level documentation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,9 +47,9 @@
       "dev": true
     },
     "atomdoc": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/atomdoc/-/atomdoc-1.1.0.tgz",
-      "integrity": "sha512-FzjIl4z4nyYg+3PaXlUuYAIQVozs1g1qyNFKKmQKV6KAJYLaDpn0BhOQ9Q5eLK5vuxF1nZEE+EgpR8LVj31BWA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/atomdoc/-/atomdoc-1.2.0.tgz",
+      "integrity": "sha512-+FbOglb00hPp3G2+XobYEcXUutZD7+jI4IrNo86PaZDdonoSeTWog75z9cO+Zjzix2dQ3cwfO7Qy4LCztLJ6vg==",
       "requires": {
         "marked": "^0.6.2"
       }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "http://atom.github.io/tello",
   "dependencies": {
-    "atomdoc": "1.1.0",
+    "atomdoc": "1.2.0",
     "underscore": "~1.6",
     "optimist": "~0.6"
   },

--- a/spec/digester-spec.coffee
+++ b/spec/digester-spec.coffee
@@ -98,6 +98,34 @@ describe 'digest', ->
     expect(json.classes.Something.instanceMethods[0].events.length).toBe 1
     expect(json.classes.Something.instanceMethods[0].events[0].description).toBe 'a method event'
 
+  it 'ignores return statements in class-level documentation', ->
+    file = """
+      # Essential: Summary.
+      #
+      # ## \`method1()\`
+      #
+      # Returns a {String}.
+      #
+      # ## \`method2()\`
+      #
+      # Returns a {Number}.
+      class Person
+        someFn: ->
+    """
+    json = Parser.generateDigest file
+    expect(json.classes.Person.summary).toBe "Summary."
+    expect(json.classes.Person.description.trim()).toBe """
+    Summary.
+
+    ## \`method1()\`
+
+    Returns a {String}.
+
+    ## \`method2()\`
+
+    Returns a {Number}.
+    """
+
   describe 'when a class has a super class', ->
     it 'generates links to github based on repo and version', ->
       file = """

--- a/src/digester.coffee
+++ b/src/digester.coffee
@@ -26,7 +26,7 @@ class Digester
     {classes}
 
   digestClass: (classEntity) ->
-    classDoc = @docFromDocString(classEntity.doc)
+    classDoc = @docFromDocString(classEntity.doc, {parseReturns: false})
     return unless classDoc
 
     sections = @filterSectionsForRowRange(classEntity.range[0][0], classEntity.range[1][0])
@@ -118,8 +118,8 @@ class Digester
       return section.name if row > section.startRow
     null
 
-  docFromDocString: (docString) ->
-    classDoc = atomdoc.parse(docString) if docString?
+  docFromDocString: (docString, options) ->
+    classDoc = atomdoc.parse(docString, options) if docString?
     if classDoc and classDoc.isPublic()
       classDoc
     else


### PR DESCRIPTION
Refs: https://github.com/atom/atom/issues/16106
Depends on: https://github.com/atom/atomdoc/pull/21

Previously, as also showcased by the test introduced with these changes, this module would interpret everything occurring after the first `Returns` token as a return value. For instance, in the example below, this manifested itself by not including any paragraph starting at `Returns a {String}` in the class' `description` field: 

```js
// Essential: Summary.
//
// ## \`method1()\`
//
// Returns a {String}.
//
// ## \`method2()\`
//
// Returns a {Number}.
```

While this behavior makes sense for functions, methods and perhaps properties, it is harmful for class documentation, where a `Returns` statement most likely refers to the usage of the class APIs rather than to the return value of the class itself.

This pull request uses the new `parseReturns` option introduced in https://github.com/atom/atomdoc/pull/21 to avoid parsing return statements when generating class-level documentation.

Next steps before merging this:

- [x] Merge https://github.com/atom/atomdoc/pull/21
- [x] Publish a new atomdoc version
- [x] Upgrade atomdoc in this repository